### PR TITLE
Allow deactivation of the creation of release notes

### DIFF
--- a/README.md
+++ b/README.md
@@ -17,33 +17,30 @@ The plugin does not have it`s own configuration, but it passes configuration to 
 ```json
 {
   "plugins": [
-    [
-      "semantic-release-unsquash",
-      {
-        "commitAnalyzerConfig": {
-          "preset": "angular",
-          "parserOpts": {
-            "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-          }
+    ["semantic-release-unsquash", {
+      "commitAnalyzerConfig": {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+        }
+      },
+      "notesGeneratorConfig": {
+        "preset": "angular",
+        "parserOpts": {
+          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
         },
-        "notesGeneratorConfig": {
-          "preset": "angular",
-          "parserOpts": {
-            "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-          },
-          "writerOpts": {
-            "commitsSort": ["subject", "scope"]
-          }
+        "writerOpts": {
+          "commitsSort": ["subject", "scope"]
         }
       }
-    ]
+    }]
   ]
 }
 ```
 
 ### Deactivate the generation of release notes
 
-To deactivate the generation of release notes, e.g. if you use your own / another plugin to generate them, you can do this with :
+To deactivate the generation of release notes, e.g. if you use your own / another plugin to generate them, you can do this with:
 
 ```json
 {
@@ -51,7 +48,7 @@ To deactivate the generation of release notes, e.g. if you use your own / anothe
     [
       "semantic-release-unsquash",
       {
-        "commitAnalyzerConfig": { ... },
+        "commitAnalyzerConfig": { },
         "notesGeneratorConfig": false
       }
     ]

--- a/README.md
+++ b/README.md
@@ -17,23 +17,44 @@ The plugin does not have it`s own configuration, but it passes configuration to 
 ```json
 {
   "plugins": [
-    ["semantic-release-unsquash", {
-      "commitAnalyzerConfig": {
-        "preset": "angular",
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
-        }
-      },
-      "notesGeneratorConfig": {
-        "preset": "angular",
-        "parserOpts": {
-          "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+    [
+      "semantic-release-unsquash",
+      {
+        "commitAnalyzerConfig": {
+          "preset": "angular",
+          "parserOpts": {
+            "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+          }
         },
-        "writerOpts": {
-          "commitsSort": ["subject", "scope"]
+        "notesGeneratorConfig": {
+          "preset": "angular",
+          "parserOpts": {
+            "noteKeywords": ["BREAKING CHANGE", "BREAKING CHANGES", "BREAKING"]
+          },
+          "writerOpts": {
+            "commitsSort": ["subject", "scope"]
+          }
         }
       }
-    }]
+    ]
+  ]
+}
+```
+
+### Deactivate the generation of release notes
+
+To deactivate the generation of release notes, e.g. if you use your own / another plugin to generate them, you can do this with :
+
+```json
+{
+  "plugins": [
+    [
+      "semantic-release-unsquash",
+      {
+        "commitAnalyzerConfig": { ... },
+        "notesGeneratorConfig": false
+      }
+    ]
   ]
 }
 ```

--- a/src/index.js
+++ b/src/index.js
@@ -19,6 +19,7 @@ const analyzeCommits = async (pluginConfig, context) => {
 
 const generateNotes = async (pluginConfig, context) => {
   const { notesGeneratorConfig } = pluginConfig || {};
+  if (notesGeneratorConfig === false) { return }
   const commits = getUnsquashedCommits(context);
 
   return originalGenerateNotes(notesGeneratorConfig ?? {}, {


### PR DESCRIPTION
This PR implements the possibility to disable the creation of release notes by simply setting `notesGeneratorConfig` to `false`.

This option is also added to the README.

We use these customizations ourselves, as we create our release notes with another plugin. Since this plugin already successfully passes on the commits, it currently creates duplicate release note entries in the changelog file without this customization.