### PR TITLE
Introduce configurable parsing

### DIFF
--- a/README.md
+++ b/README.md
@@ -98,7 +98,8 @@ and expands squashed commits inside the merge commit body:
 - `sectionRegexStr`: alternative regex selector. If it contains a capture
   group, that content is used; otherwise the matched substring is parsed.
 - `listItemPrefixes` / `listItemPrefix`: configure bullet prefixes if you use
-  something other than the defaults (`* `, `- `, `+ `).
+  something other than the default (`* `). For example, specify `["- "]` if
+  your squashed commit list uses dash bullets.
 - `listItemRegexStr`: full custom matcher for bullets (takes priority over
   prefixes), useful for compact formats such as `*feat: ...`.
 

--- a/README.md
+++ b/README.md
@@ -69,3 +69,38 @@ To use this plugin with GitLab, you need to go to your project settings and in t
 
 %{all_commits}
 ```
+
+## Configuring commit section detection
+
+You can pass `getUnsquashedCommitsConfig` to fine‑tune how the plugin finds
+and expands squashed commits inside the merge commit body:
+
+```json
+{
+  "plugins": [
+    [
+      "semantic-release-unsquash",
+      {
+        "getUnsquashedCommitsConfig": {
+          "sectionHeading": "### Changes",
+          "sectionRegexStr": "### Changes(?:\\n|\\r\\n){2}([\\s\\S]*?)(?=$)",
+          "listItemPrefixes": ["* ", "- "],
+          "listItemRegexStr": "^\\s*\\*"
+        }
+      }
+    ]
+  ]
+}
+```
+
+- `sectionHeading`: literal string to locate the start of the commit list.
+  Everything after the heading (trimmed) is parsed.
+- `sectionRegexStr`: alternative regex selector. If it contains a capture
+  group, that content is used; otherwise the matched substring is parsed.
+- `listItemPrefixes` / `listItemPrefix`: configure bullet prefixes if you use
+  something other than the defaults (`* `, `- `, `+ `).
+- `listItemRegexStr`: full custom matcher for bullets (takes priority over
+  prefixes), useful for compact formats such as `*feat: ...`.
+
+These options can be combined. Multi-line commit bodies remain attached to the
+bullet that introduced them.

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -23,7 +23,7 @@
  */
 
 /** @type {string[]} Default bullet prefixes recognised when none are provided. */
-const DEFAULT_LIST_ITEM_PREFIXES = ['* ', '- ', '+ '];
+const DEFAULT_LIST_ITEM_PREFIXES = ['* '];
 
 /**
  * Escapes literal characters so they can be embedded inside a regex safely.

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -1,7 +1,44 @@
+/**
+ * @typedef {Object} Commit
+ * @property {string} subject
+ * @property {string} [body]
+ * @property {string} [hash]
+ * @property {string} [message]
+ * @property {Object.<string, unknown>} [raw]
+ */
+
+/**
+ * @typedef {Object} GetUnsquashedCommitsConfig
+ * @property {string} [sectionHeading] Heading string that precedes the commit list.
+ * @property {string} [sectionRegexStr] Regex used to extract the commit list section.
+ * @property {string[]} [listItemPrefixes] Bullet prefixes treated as list markers.
+ * @property {string} [listItemPrefix] Single bullet prefix shorthand.
+ * @property {string} [listItemRegexStr] Custom regex to detect list markers.
+ */
+
+/**
+ * @typedef {Object} ListItemMatcher
+ * @property {(line: string) => boolean} isListItem Checks if a line is a list item.
+ * @property {(line: string) => string} stripPrefix Removes the marker from a line.
+ */
+
+/** @type {string[]} Default bullet prefixes recognised when none are provided. */
 const DEFAULT_LIST_ITEM_PREFIXES = ['* ', '- ', '+ '];
 
+/**
+ * Escapes literal characters so they can be embedded inside a regex safely.
+ *
+ * @param {string} value
+ * @returns {string}
+ */
 const escapeForRegex = (value) => value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
 
+/**
+ * Normalises the configured list item prefixes, falling back to defaults.
+ *
+ * @param {GetUnsquashedCommitsConfig} [config]
+ * @returns {string[]}
+ */
 const getListItemPrefixes = (config = {}) => {
   const prefixes = [];
   const { listItemPrefixes, listItemPrefix } = config;
@@ -25,6 +62,12 @@ const getListItemPrefixes = (config = {}) => {
   return [...new Set(prefixes)];
 };
 
+/**
+ * Builds helpers that can recognise and strip bullet markers from lines.
+ *
+ * @param {GetUnsquashedCommitsConfig} [config]
+ * @returns {ListItemMatcher | null}
+ */
 const createListItemMatcher = (config = {}) => {
   const { listItemRegexStr } = config;
 
@@ -64,6 +107,13 @@ const createListItemMatcher = (config = {}) => {
   };
 };
 
+/**
+ * Extracts the portion of a squashed commit body that contains the commit list.
+ *
+ * @param {string} [body]
+ * @param {GetUnsquashedCommitsConfig} [config]
+ * @returns {string}
+ */
 const selectCommitSection = (body = '', config = {}) => {
   if (!body) {
     return '';
@@ -92,6 +142,13 @@ const selectCommitSection = (body = '', config = {}) => {
   return body;
 };
 
+/**
+ * Converts a commit list section into individual message blocks.
+ *
+ * @param {string} sectionText
+ * @param {ListItemMatcher | null} matcher
+ * @returns {string[]}
+ */
 const splitSquashedMessages = (sectionText, matcher) => {
   if (!sectionText || !matcher) {
     return [];
@@ -123,6 +180,13 @@ const splitSquashedMessages = (sectionText, matcher) => {
   return messages.filter((message) => message.length > 0);
 };
 
+/**
+ * Expands squashed commits into individual commit objects for downstream plugins.
+ *
+ * @param {{ commits: Commit[] }} context Semantic-release context containing commits.
+ * @param {GetUnsquashedCommitsConfig} [pluginConfig]
+ * @returns {Commit[]}
+ */
 const getUnsquashedCommits = (context, pluginConfig = {}) => {
   const { commits } = context;
   const matcher = createListItemMatcher(pluginConfig);

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -72,17 +72,25 @@ const createListItemMatcher = (config = {}) => {
   const { listItemRegexStr } = config;
 
   if (typeof listItemRegexStr === 'string' && listItemRegexStr.length > 0) {
-    const userRegex = new RegExp(listItemRegexStr);
-    return {
-      isListItem(line) {
-        userRegex.lastIndex = 0;
-        return userRegex.test(line);
-      },
-      stripPrefix(line) {
-        userRegex.lastIndex = 0;
-        return line.replace(userRegex, '');
-      },
-    };
+    let userRegex;
+    try {
+      userRegex = new RegExp(listItemRegexStr);
+    } catch (_) {
+      userRegex = null;
+    }
+
+    if (userRegex) {
+      return {
+        isListItem(line) {
+          userRegex.lastIndex = 0;
+          return userRegex.test(line);
+        },
+        stripPrefix(line) {
+          userRegex.lastIndex = 0;
+          return line.replace(userRegex, '');
+        },
+      };
+    }
   }
 
   const prefixes = getListItemPrefixes(config);
@@ -122,13 +130,17 @@ const selectCommitSection = (body = '', config = {}) => {
   const { sectionRegexStr, sectionHeading } = config;
 
   if (typeof sectionRegexStr === 'string' && sectionRegexStr.length > 0) {
-    const sectionRegex = new RegExp(sectionRegexStr, 'g');
-    const match = sectionRegex.exec(body);
-    if (match) {
-      const capturedGroup = match
-        .slice(1)
-        .find((value) => typeof value === 'string' && value !== undefined);
-      return (capturedGroup ?? match[0]).trim();
+    try {
+      const sectionRegex = new RegExp(sectionRegexStr, 'g');
+      const match = sectionRegex.exec(body);
+      if (match) {
+        const capturedGroup = match
+          .slice(1)
+          .find((value) => typeof value === 'string' && value !== undefined);
+        return (capturedGroup ?? match[0]).trim();
+      }
+    } catch (_) {
+      // Fall through to heading/default behavior
     }
   }
 

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -190,10 +190,25 @@ const splitSquashedMessages = (sectionText, matcher) => {
 const getUnsquashedCommits = (context, pluginConfig = {}) => {
   const { commits } = context;
   const matcher = createListItemMatcher(pluginConfig);
+  const hasSectionRegex =
+    typeof pluginConfig.sectionRegexStr === 'string' &&
+    pluginConfig.sectionRegexStr.length > 0;
+  const hasSectionHeading =
+    typeof pluginConfig.sectionHeading === 'string' &&
+    pluginConfig.sectionHeading.length > 0;
+  const shouldVerifyFirstLine = !hasSectionRegex && !hasSectionHeading;
 
   return commits.reduce((acc, commit) => {
     const body = commit.body ?? '';
     const sectionText = selectCommitSection(body, pluginConfig);
+    if (shouldVerifyFirstLine) {
+      const firstNonEmptyLine =
+        sectionText.split(/\r?\n/).find((line) => line.trim().length > 0) ?? '';
+
+      if (!matcher?.isListItem(firstNonEmptyLine)) {
+        return [...acc, commit];
+      }
+    }
     const squashedMessages = splitSquashedMessages(sectionText, matcher);
 
     if (squashedMessages.length === 0) {

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -1,12 +1,21 @@
-const getUnsquashedCommits = (context) => {
+const getUnsquashedCommits = (context, pluginConfig) => {
+  const { sectionRegexStr } = pluginConfig || {};
   const { commits } = context;
 
   return commits.reduce((acc, commit) => {
-    if (!commit.body.startsWith('* ')) {
+    let commitsBody = commit.body;
+    if (sectionRegexStr) {
+      const sectionRegex = new RegExp(sectionRegexStr, 'g');
+      const match = sectionRegex.exec(commit.body);
+      if (match) {
+        commitsBody = match[1].trim();
+      }
+    }
+    if (!commitsBody.startsWith('* ')) {
       return [...acc, commit];
     }
 
-    const squashedCommits = commit.body.split('*').map((line) => line.trim());
+    const squashedCommits = commitsBody.split('*').map((line) => line.trim());
 
     return [
       ...acc,

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -210,7 +210,9 @@ const getUnsquashedCommits = (context, pluginConfig = {}) => {
     pluginConfig.sectionHeading.length > 0;
   const shouldVerifyFirstLine = !hasSectionRegex && !hasSectionHeading;
 
-  return commits.reduce((acc, commit) => {
+  const unsquashedCommits = [];
+
+  for (const commit of commits) {
     const body = commit.body ?? '';
     const sectionText = selectCommitSection(body, pluginConfig);
     if (shouldVerifyFirstLine) {
@@ -218,13 +220,15 @@ const getUnsquashedCommits = (context, pluginConfig = {}) => {
         sectionText.split(/\r?\n/).find((line) => line.trim().length > 0) ?? '';
 
       if (!matcher?.isListItem(firstNonEmptyLine)) {
-        return [...acc, commit];
+        unsquashedCommits.push(commit);
+        continue;
       }
     }
     const squashedMessages = splitSquashedMessages(sectionText, matcher);
 
     if (squashedMessages.length === 0) {
-      return [...acc, commit];
+      unsquashedCommits.push(commit);
+      continue;
     }
 
     const unsquashed = squashedMessages
@@ -248,7 +252,8 @@ const getUnsquashedCommits = (context, pluginConfig = {}) => {
       .filter(Boolean);
 
     if (unsquashed.length === 0) {
-      return [...acc, commit];
+      unsquashedCommits.push(commit);
+      continue;
     }
 
     const placeholderCommit = {
@@ -258,8 +263,10 @@ const getUnsquashedCommits = (context, pluginConfig = {}) => {
       message: '',
     };
 
-    return [...acc, placeholderCommit, ...unsquashed];
-  }, []);
+    unsquashedCommits.push(placeholderCommit, ...unsquashed);
+  }
+
+  return unsquashedCommits;
 };
 
 module.exports = { getUnsquashedCommits };

--- a/src/get-unsquashed-commits.js
+++ b/src/get-unsquashed-commits.js
@@ -1,34 +1,173 @@
-const getUnsquashedCommits = (context, pluginConfig) => {
-  const { sectionRegexStr } = pluginConfig || {};
+const DEFAULT_LIST_ITEM_PREFIXES = ['* ', '- ', '+ '];
+
+const escapeForRegex = (value) => value.replace(/[|\\{}()[\]^$+*?.-]/g, '\\$&');
+
+const getListItemPrefixes = (config = {}) => {
+  const prefixes = [];
+  const { listItemPrefixes, listItemPrefix } = config;
+
+  if (Array.isArray(listItemPrefixes)) {
+    prefixes.push(
+      ...listItemPrefixes.filter(
+        (prefix) => typeof prefix === 'string' && prefix.length > 0,
+      ),
+    );
+  }
+
+  if (typeof listItemPrefix === 'string' && listItemPrefix.length > 0) {
+    prefixes.push(listItemPrefix);
+  }
+
+  if (prefixes.length === 0) {
+    return DEFAULT_LIST_ITEM_PREFIXES;
+  }
+
+  return [...new Set(prefixes)];
+};
+
+const createListItemMatcher = (config = {}) => {
+  const { listItemRegexStr } = config;
+
+  if (typeof listItemRegexStr === 'string' && listItemRegexStr.length > 0) {
+    const userRegex = new RegExp(listItemRegexStr);
+    return {
+      isListItem(line) {
+        userRegex.lastIndex = 0;
+        return userRegex.test(line);
+      },
+      stripPrefix(line) {
+        userRegex.lastIndex = 0;
+        return line.replace(userRegex, '');
+      },
+    };
+  }
+
+  const prefixes = getListItemPrefixes(config);
+  if (prefixes.length === 0) {
+    return null;
+  }
+
+  const prefixPattern = `^\\s*(?:${prefixes
+    .map((prefix) => escapeForRegex(prefix))
+    .join('|')})`;
+  const prefixRegex = new RegExp(prefixPattern);
+
+  return {
+    isListItem(line) {
+      prefixRegex.lastIndex = 0;
+      return prefixRegex.test(line);
+    },
+    stripPrefix(line) {
+      prefixRegex.lastIndex = 0;
+      return line.replace(prefixRegex, '');
+    },
+  };
+};
+
+const selectCommitSection = (body = '', config = {}) => {
+  if (!body) {
+    return '';
+  }
+
+  const { sectionRegexStr, sectionHeading } = config;
+
+  if (typeof sectionRegexStr === 'string' && sectionRegexStr.length > 0) {
+    const sectionRegex = new RegExp(sectionRegexStr, 'g');
+    const match = sectionRegex.exec(body);
+    if (match) {
+      const capturedGroup = match
+        .slice(1)
+        .find((value) => typeof value === 'string' && value !== undefined);
+      return (capturedGroup ?? match[0]).trim();
+    }
+  }
+
+  if (typeof sectionHeading === 'string' && sectionHeading.length > 0) {
+    const index = body.indexOf(sectionHeading);
+    if (index !== -1) {
+      return body.slice(index + sectionHeading.length).trimStart();
+    }
+  }
+
+  return body;
+};
+
+const splitSquashedMessages = (sectionText, matcher) => {
+  if (!sectionText || !matcher) {
+    return [];
+  }
+
+  const lines = sectionText.split(/\r?\n/);
+  const messages = [];
+  let currentLines = null;
+
+  lines.forEach((line) => {
+    if (matcher.isListItem(line)) {
+      if (currentLines && currentLines.length > 0) {
+        messages.push(currentLines.join('\n').trim());
+      }
+      const strippedLine = matcher.stripPrefix(line).trimStart();
+      currentLines = [strippedLine];
+      return;
+    }
+
+    if (currentLines) {
+      currentLines.push(line);
+    }
+  });
+
+  if (currentLines && currentLines.length > 0) {
+    messages.push(currentLines.join('\n').trim());
+  }
+
+  return messages.filter((message) => message.length > 0);
+};
+
+const getUnsquashedCommits = (context, pluginConfig = {}) => {
   const { commits } = context;
+  const matcher = createListItemMatcher(pluginConfig);
 
   return commits.reduce((acc, commit) => {
-    let commitsBody = commit.body;
-    if (sectionRegexStr) {
-      const sectionRegex = new RegExp(sectionRegexStr, 'g');
-      const match = sectionRegex.exec(commit.body);
-      if (match) {
-        commitsBody = match[1].trim();
-      }
-    }
-    if (!commitsBody.startsWith('* ')) {
+    const body = commit.body ?? '';
+    const sectionText = selectCommitSection(body, pluginConfig);
+    const squashedMessages = splitSquashedMessages(sectionText, matcher);
+
+    if (squashedMessages.length === 0) {
       return [...acc, commit];
     }
 
-    const squashedCommits = commitsBody.split('*').map((line) => line.trim());
+    const unsquashed = squashedMessages
+      .map((message) => {
+        const normalizedMessage = message.replace(/\r\n/g, '\n').trim();
+        const [subjectLine = '', ...rest] = normalizedMessage.split('\n');
+        const subject = subjectLine.trim();
+        const bodyLines = rest.join('\n').trim();
 
-    return [
-      ...acc,
-      ...squashedCommits.map((squashedCommit) => {
-        const [subject, , ...body] = squashedCommit.split('\n');
+        if (!subject) {
+          return null;
+        }
+
         return {
           ...commit,
           subject,
-          body: body.join('\n'),
-          message: squashedCommit,
+          body: bodyLines,
+          message: normalizedMessage,
         };
-      }),
-    ];
+      })
+      .filter(Boolean);
+
+    if (unsquashed.length === 0) {
+      return [...acc, commit];
+    }
+
+    const placeholderCommit = {
+      ...commit,
+      subject: '',
+      body: '',
+      message: '',
+    };
+
+    return [...acc, placeholderCommit, ...unsquashed];
   }, []);
 };
 

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -145,5 +145,223 @@ describe(getUnsquashedCommits.name, () => {
         ]
       `);
     });
+
+    it('should fall back to whole match when sectionRegex has no capture group', () => {
+      const commits = [
+        {
+          subject: 'Init',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '* refactor: adjust workflow (f8c544a)\n' +
+            '\n' +
+            '* docs: document shared module (40129ad)\n',
+          hash: 'b671c1a316c6205ac8fb73313f9c2fbeeb66b1d5',
+          message: 'Init',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionRegexStr: String.raw`### Changes(?:\n|\r\n){2}[\s\S]*?(?=$)`,
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'refactor: adjust workflow (f8c544a)',
+          body: '',
+          message: 'refactor: adjust workflow (f8c544a)',
+        },
+        {
+          ...commits[0],
+          subject: 'docs: document shared module (40129ad)',
+          body: '',
+          message: 'docs: document shared module (40129ad)',
+        },
+      ]);
+    });
+
+    it('should use sectionHeading when provided', () => {
+      const commits = [
+        {
+          subject: 'refactor: move workflow',
+          body:
+            'refactor: move workflow to script for better testing process (#2)\n' +
+            '### Overview\n' +
+            '\n' +
+            'Details about the changes\n' +
+            '\n' +
+            '### Changes\n' +
+            '- refactor: move workflow to script for better testing process (f8c544a)\n' +
+            '- docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)\n',
+          hash: 'd5b14fc5f5438214cb643b846579c94f0bd68e24',
+          message: 'squashed commit',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionHeading: '### Changes',
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'refactor: move workflow to script for better testing process (f8c544a)',
+          body: '',
+          message:
+            'refactor: move workflow to script for better testing process (f8c544a)',
+        },
+        {
+          ...commits[0],
+          subject:
+            'docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)',
+          body: '',
+          message:
+            'docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)',
+        },
+      ]);
+    });
+
+    it('should support multi-line commits and configurable list item prefixes', () => {
+      const commits = [
+        {
+          subject: 'feature: summary',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '* refactor: move workflow to script for better testing process (f8c544a)\n' +
+            '  \n' +
+            '  body of the first commit\n' +
+            '- docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)\n' +
+            '  \n' +
+            '  body of the second commit\n',
+          hash: 'a6c8de336a46f19e8bad017d53e8eee329b40621',
+          message: 'feature summary',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionHeading: '### Changes',
+        listItemPrefixes: ['* ', '- '],
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'refactor: move workflow to script for better testing process (f8c544a)',
+          body: 'body of the first commit',
+          message:
+            'refactor: move workflow to script for better testing process (f8c544a)\n  \n  body of the first commit',
+        },
+        {
+          ...commits[0],
+          subject:
+            'docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)',
+          body: 'body of the second commit',
+          message:
+            'docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)\n  \n  body of the second commit',
+        },
+      ]);
+    });
+
+    it('should support custom listItemRegexStr for non-space bullet style', () => {
+      const commits = [
+        {
+          subject: 'feat: compact bullets',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '*refactor: adjust workflow (f8c544a)\n' +
+            '*docs: document shared module (40129ad)\n',
+          hash: 'fccf5a587416e71d23aeb502f38fd2af455a8287',
+          message: 'feat compact bullets',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionHeading: '### Changes',
+        listItemRegexStr: String.raw`^\s*\*`,
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'refactor: adjust workflow (f8c544a)',
+          body: '',
+          message: 'refactor: adjust workflow (f8c544a)',
+        },
+        {
+          ...commits[0],
+          subject: 'docs: document shared module (40129ad)',
+          body: '',
+          message: 'docs: document shared module (40129ad)',
+        },
+      ]);
+    });
+
+    it('should honor listItemPrefix when a single custom marker is provided', () => {
+      const commits = [
+        {
+          subject: 'feat: custom prefix',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '-> feat: add timeline widget (1234567)\n' +
+            '-> fix: stop crash on safari (89abcde)\n',
+          hash: 'e77d38081d69ee053f6bf17d0fd68de6a0c623f8',
+          message: 'custom prefix commit',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionHeading: '### Changes',
+        listItemPrefix: '-> ',
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'feat: add timeline widget (1234567)',
+          body: '',
+          message: 'feat: add timeline widget (1234567)',
+        },
+        {
+          ...commits[0],
+          subject: 'fix: stop crash on safari (89abcde)',
+          body: '',
+          message: 'fix: stop crash on safari (89abcde)',
+        },
+      ]);
+    });
   });
 });

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -129,6 +129,24 @@ describe(getUnsquashedCommits.name, () => {
     ]);
   });
 
+  it('should not split when only "-" bullets are present without custom prefixes', () => {
+    const commits = [
+      {
+        subject: 'docs: changelog updates',
+        body: '- fix: adjust workflow docs\n- chore: cleanup unused scripts\n',
+        hash: '0d63669040808f99dde29bc1b08346ab4e572572',
+        message:
+          'docs: changelog updates\n' +
+          '\n' +
+          '- fix: adjust workflow docs\n' +
+          '- chore: cleanup unused scripts\n',
+      },
+    ];
+    const context = { commits };
+
+    expect(getUnsquashedCommits(context)).toEqual(commits);
+  });
+
   describe('with pluginConfig', () => {
     it('should return unsquashed commits with sectionRegex', () => {
       const commits = [
@@ -308,6 +326,7 @@ describe(getUnsquashedCommits.name, () => {
       const context = { commits };
       const pluginConfig = {
         sectionHeading: '### Changes',
+        listItemPrefixes: ['- '],
       };
 
       expect(getUnsquashedCommits(context, pluginConfig)).toEqual([

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -167,7 +167,8 @@ describe(getUnsquashedCommits.name, () => {
         sectionRegexStr: '### Changes(?:\n|\\n|\\\\n){2}([\\s\\S]*?)(?=$)',
       };
 
-      expect(getUnsquashedCommits(context, pluginConfig)).toMatchInlineSnapshot(`
+      expect(getUnsquashedCommits(context, pluginConfig))
+        .toMatchInlineSnapshot(`
         [
           {
             "body": "",
@@ -318,7 +319,8 @@ describe(getUnsquashedCommits.name, () => {
         },
         {
           ...commits[0],
-          subject: 'refactor: move workflow to script for better testing process (f8c544a)',
+          subject:
+            'refactor: move workflow to script for better testing process (f8c544a)',
           body: '',
           message:
             'refactor: move workflow to script for better testing process (f8c544a)',
@@ -366,7 +368,8 @@ describe(getUnsquashedCommits.name, () => {
         },
         {
           ...commits[0],
-          subject: 'refactor: move workflow to script for better testing process (f8c544a)',
+          subject:
+            'refactor: move workflow to script for better testing process (f8c544a)',
           body: 'body of the first commit',
           message:
             'refactor: move workflow to script for better testing process (f8c544a)\n  \n  body of the first commit',

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -70,6 +70,65 @@ describe(getUnsquashedCommits.name, () => {
     `);
   });
 
+  it('should leave commit unchanged when the first non-empty line is not a list item', () => {
+    const commits = [
+      {
+        subject: 'docs: update README',
+        body:
+          'docs: update README with deployment steps\n' +
+          '\n' +
+          '* chore: unrelated bullet that should be ignored\n',
+        hash: 'd5b14fc5f5438214cb643b846579c94f0bd68e24',
+        message:
+          'docs: update README\n' +
+          '\n' +
+          'docs: update README with deployment steps\n' +
+          '\n' +
+          '* chore: unrelated bullet that should be ignored',
+      },
+    ];
+    const context = { commits };
+
+    expect(getUnsquashedCommits(context)).toEqual(commits);
+  });
+
+  it('should split when the first list item follows leading blank lines', () => {
+    const commits = [
+      {
+        subject: 'chore: release v1.2.3',
+        body: '\n* fix: correct typo in docs\n* feat: add deployment script',
+        hash: 'd5b14fc5f5438214cb643b846579c94f0bd68e24',
+        message:
+          'chore: release v1.2.3\n' +
+          '\n' +
+          '* fix: correct typo in docs\n' +
+          '* feat: add deployment script',
+      },
+    ];
+    const context = { commits };
+
+    expect(getUnsquashedCommits(context)).toEqual([
+      {
+        ...commits[0],
+        subject: '',
+        body: '',
+        message: '',
+      },
+      {
+        ...commits[0],
+        subject: 'fix: correct typo in docs',
+        body: '',
+        message: 'fix: correct typo in docs',
+      },
+      {
+        ...commits[0],
+        subject: 'feat: add deployment script',
+        body: '',
+        message: 'feat: add deployment script',
+      },
+    ]);
+  });
+
   describe('with pluginConfig', () => {
     it('should return unsquashed commits with sectionRegex', () => {
       const commits = [

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -246,6 +246,47 @@ describe(getUnsquashedCommits.name, () => {
       ]);
     });
 
+    it('should fall back to sectionHeading when sectionRegexStr is invalid', () => {
+      const commits = [
+        {
+          subject: 'refactor: invalid regex',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '* fix: patch issue (1234567)\n' +
+            '* feat: add improvement (7654321)\n',
+          hash: 'd5b14fc5f5438214cb643b846579c94f0bd68e24',
+          message: 'refactor: invalid regex',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        sectionRegexStr: '[',
+        sectionHeading: '### Changes',
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'fix: patch issue (1234567)',
+          body: '',
+          message: 'fix: patch issue (1234567)',
+        },
+        {
+          ...commits[0],
+          subject: 'feat: add improvement (7654321)',
+          body: '',
+          message: 'feat: add improvement (7654321)',
+        },
+      ]);
+    });
+
     it('should use sectionHeading when provided', () => {
       const commits = [
         {
@@ -337,6 +378,46 @@ describe(getUnsquashedCommits.name, () => {
           body: 'body of the second commit',
           message:
             'docs: added JSDoc blocks describing function purpose, inputs, and outputs so the shared action module is self-documented (40129ad)\n  \n  body of the second commit',
+        },
+      ]);
+    });
+
+    it('should fall back to defaults when listItemRegexStr is invalid', () => {
+      const commits = [
+        {
+          subject: 'feat: fallback',
+          body: '* fix: address crash\n* chore: tidy scripts\n',
+          hash: 'd5b14fc5f5438214cb643b846579c94f0bd68e24',
+          message:
+            'feat: fallback\n' +
+            '\n' +
+            '* fix: address crash\n' +
+            '* chore: tidy scripts\n',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        listItemRegexStr: '[',
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toEqual([
+        {
+          ...commits[0],
+          subject: '',
+          body: '',
+          message: '',
+        },
+        {
+          ...commits[0],
+          subject: 'fix: address crash',
+          body: '',
+          message: 'fix: address crash',
+        },
+        {
+          ...commits[0],
+          subject: 'chore: tidy scripts',
+          body: '',
+          message: 'chore: tidy scripts',
         },
       ]);
     });

--- a/src/get-unsquashed-commits.spec.js
+++ b/src/get-unsquashed-commits.spec.js
@@ -69,4 +69,81 @@ describe(getUnsquashedCommits.name, () => {
       ]
     `);
   });
+
+  describe('with pluginConfig', () => {
+    it('should return unsquashed commits with sectionRegex', () => {
+      const commits = [
+        {
+          subject: 'Init',
+          body:
+            '### Changes\n' +
+            '\n' +
+            '* fix: restrict job branches\n' +
+            '\n' +
+            'Foobar string\n' +
+            '\n' +
+            '* ci: use image with git\n' +
+            '\n' +
+            '* ci: fix job\n' +
+            '\n' +
+            '* feat: initial commit\n',
+          hash: '0d63669040808f99dde29bc1b08346ab4e572572',
+          message:
+            'Init\n' +
+            '\n' +
+            '* fix: restrict job branches\n' +
+            '\n' +
+            'Foobar string\n' +
+            '\n' +
+            '* ci: use image with git\n' +
+            '\n' +
+            '* ci: fix job\n' +
+            '\n' +
+            '* feat: initial commit',
+        },
+      ];
+      const context = { commits };
+      const pluginConfig = {
+        // Another sample may be ### Changes(?:\n|\\n|\\\\n){2}([\s\S]*?)(?=###)
+        sectionRegexStr: '### Changes(?:\n|\\n|\\\\n){2}([\\s\\S]*?)(?=$)',
+      };
+
+      expect(getUnsquashedCommits(context, pluginConfig)).toMatchInlineSnapshot(`
+        [
+          {
+            "body": "",
+            "hash": "0d63669040808f99dde29bc1b08346ab4e572572",
+            "message": "",
+            "subject": "",
+          },
+          {
+            "body": "Foobar string",
+            "hash": "0d63669040808f99dde29bc1b08346ab4e572572",
+            "message": "fix: restrict job branches
+
+        Foobar string",
+            "subject": "fix: restrict job branches",
+          },
+          {
+            "body": "",
+            "hash": "0d63669040808f99dde29bc1b08346ab4e572572",
+            "message": "ci: use image with git",
+            "subject": "ci: use image with git",
+          },
+          {
+            "body": "",
+            "hash": "0d63669040808f99dde29bc1b08346ab4e572572",
+            "message": "ci: fix job",
+            "subject": "ci: fix job",
+          },
+          {
+            "body": "",
+            "hash": "0d63669040808f99dde29bc1b08346ab4e572572",
+            "message": "feat: initial commit",
+            "subject": "feat: initial commit",
+          },
+        ]
+      `);
+    });
+  });
 });

--- a/src/index.js
+++ b/src/index.js
@@ -8,8 +8,9 @@ const {
 const { getUnsquashedCommits } = require('./get-unsquashed-commits');
 
 const analyzeCommits = async (pluginConfig, context) => {
-  const { commitAnalyzerConfig } = pluginConfig || {};
-  const commits = getUnsquashedCommits(context);
+  const { commitAnalyzerConfig, getUnsquashedCommitsConfig } =
+    pluginConfig || {};
+  const commits = getUnsquashedCommits(context, getUnsquashedCommitsConfig);
 
   return originalAnalyzeCommits(commitAnalyzerConfig ?? {}, {
     ...context,
@@ -18,9 +19,12 @@ const analyzeCommits = async (pluginConfig, context) => {
 };
 
 const generateNotes = async (pluginConfig, context) => {
-  const { notesGeneratorConfig } = pluginConfig || {};
-  if (notesGeneratorConfig === false) { return }
-  const commits = getUnsquashedCommits(context);
+  const { notesGeneratorConfig, getUnsquashedCommitsConfig } =
+    pluginConfig || {};
+  if (notesGeneratorConfig === false) {
+    return;
+  }
+  const commits = getUnsquashedCommits(context, getUnsquashedCommitsConfig);
 
   return originalGenerateNotes(notesGeneratorConfig ?? {}, {
     ...context,


### PR DESCRIPTION
## 📄 Summary

Introduce configurable parsing so the plugin can unpack squashed commits using custom headings and bullet formats, while documenting the new options. These changes also harden multi-line handling and route the configuration through the analyze and notes stages.

---

## 🔍 Changes

- Extend `getUnsquashedCommits` with helpers for custom section selectors and list markers, preserving multi-line commit bodies
- Wire `getUnsquashedCommitsConfig` into commit analysis and note generation so downstream plugins honor the overrides
- Document the configuration shape in `README.md` and add Jest coverage for the new parsing scenarios

---

## ✅ Checklist

- [x] Code works as expected
- [x] Tests added/updated (if needed)
- [x] Docs updated (if needed)

---

## 🧪 Testing

Steps to test:

1. Run `npm test` to execute the Jest suite
2. Integrate the plugin with a `getUnsquashedCommitsConfig` override and confirm customized commit extraction